### PR TITLE
Add flattened shortcuts for long paths without branching

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -54,9 +54,13 @@ struct GithubGraphqlResponse: DeepDecodable {
 		static let codingTree = CodingTree {
 			Key("name", containing: \._name)
 
+			Key("field", "name", containing: \._fieldName)
+			/*
+			The above is a "flattened" shortcut for:
 			Key("field") {
 				Key("name", containing: \._fieldName)
 			}
+			*/
 		}
 
 
@@ -110,6 +114,12 @@ struct DeeplyNestedResponse: DeepDecodable {
 			}
 		}
 	}
+	/*
+	Also valid is the flattened form:
+	static let codingTree = CodingTree {
+		Key("topLevel", "secondLevel", "thirdLevel", containing: \._property)
+	}
+	*/
 
 	@Value var property: String
 }
@@ -157,6 +167,16 @@ struct DeeplyNestedRequest: DeepEncodable {
 			Key("otherSecondLevel", containing: \._wrappedProperty)
 		}
 	}
+	/*
+	Also valid is the flattened form:
+	static let codingTree = CodingTree {
+		Key("topLevel") {
+			Key("secondLevel", "thirdLevel", containing: \.bareProperty)
+
+			Key("otherSecondLevel", containing: \._wrappedProperty)
+		}
+	}
+	*/
 
 	let bareProperty: String
 	@Value var wrappedProperty: String
@@ -194,3 +214,6 @@ With encoding, you don't have to use the `@Value` wrappers, though you can if yo
 
 - Omission of the corresponding tree sections when all values at the leaves are `nil`
 	- This makes it so trying to encode an object with a `nil` value doesn't result in something like `{"top": {"second": {"third": null} } }`
+
+- Flattened shortcuts using variadic parameters for long paths with no branching:
+	- `Key("topLevel", "secondLevel", containing: \._property)` instead of `Key("topLevel") { Key("secondLevel", containing: \._property) }`

--- a/Tests/DeepCodableTests/DecodingTests.swift
+++ b/Tests/DeepCodableTests/DecodingTests.swift
@@ -176,6 +176,45 @@ final class DecodingTests: XCTestCase {
 		XCTAssertEqual("tenthValue", decoded.key)
 	}
 
+	/// Test that decoding a deep ten-level JSON body using a flattened coding tree decodes the correct value.
+	func testFlattenedExcessivelyDeepDecoding() throws {
+		struct FlattenedExcessivelyDeepDecoding: DeepDecodable {
+			static let codingTree = CodingTree {
+				Key("top", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth", containing: \._key)
+			}
+
+			@Value var key: String
+		}
+
+		let json = """
+			{
+				"top": {
+					"second": {
+						"third": {
+							"fourth": {
+								"fifth": {
+									"sixth": {
+										"seventh": {
+											"eighth": {
+												"ninth": {
+													"tenth": "tenthValue"
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			"""
+
+		let decoded = try decode(FlattenedExcessivelyDeepDecoding.self, from: json)
+
+		XCTAssertEqual("tenthValue", decoded.key)
+	}
+
 	/// Test that decoding a deep ten-level JSON body with two keys in different branches decodes the correct values.
 	func testBranchedExcessivelyDeepDecoding() throws {
 		struct BranchedExcessivelyDeepDecoding: DeepDecodable {
@@ -250,6 +289,57 @@ final class DecodingTests: XCTestCase {
 		XCTAssertEqual("ninth2Value", decoded.key2)
 	}
 
+	/// Test that decoding a deep ten-level JSON body with two keys in different branches using a flattened coding tree decodes the correct values.
+	func testFlattenedBranchedExcessivelyDeepDecoding() throws {
+		struct FlattenedBranchedExcessivelyDeepDecoding: DeepDecodable {
+			static let codingTree = CodingTree {
+				Key("top", "second", "third", "fourth", "fifth") {
+					Key("sixth1", "seventh1", "eighth1", "ninth1", "tenth1", containing: \._key1)
+					Key("sixth2", "seventh2", "eighth2", "ninth2", containing: \._key2)
+				}
+			}
+
+			@Value var key1: String
+			@Value var key2: String
+		}
+
+		let json = """
+			{
+				"top": {
+					"second": {
+						"third": {
+							"fourth": {
+								"fifth": {
+									"sixth1": {
+										"seventh1": {
+											"eighth1": {
+												"ninth1": {
+													"tenth1": "tenth1Value"
+												}
+											}
+										}
+									},
+									"sixth2": {
+										"seventh2": {
+											"eighth2": {
+												"ninth2": "ninth2Value"
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			"""
+
+		let decoded = try decode(FlattenedBranchedExcessivelyDeepDecoding.self, from: json)
+
+		XCTAssertEqual("tenth1Value", decoded.key1)
+		XCTAssertEqual("ninth2Value", decoded.key2)
+	}
+
 
 	/// Test that optionals decode correctly when provided an actual value.
 	func testOptionalDecodingToValue() throws {
@@ -291,6 +381,47 @@ final class DecodingTests: XCTestCase {
 			{}
 			"""
 		let decoded = try decode(OptionalDecodingToNil.self, from: json)
+
+		XCTAssertEqual(nil, decoded.key)
+	}
+
+
+	/// Test that optionals decode correctly using a flattened coding tree when provided an actual value.
+	func testFlattenedOptionalDecodingToValue() throws {
+		struct FlattenedOptionalDecodingToValue: DeepDecodable {
+			static let codingTree = CodingTree {
+				Key("top", "second", containing: \._key)
+			}
+
+			@Value var key: String?
+		}
+
+		let json = """
+			{
+				"top": {
+					"second": "secondValue"
+				}
+			}
+			"""
+		let decoded = try decode(FlattenedOptionalDecodingToValue.self, from: json)
+
+		XCTAssertEqual("secondValue", decoded.key)
+	}
+
+	/// Test that optionals decode correctly using a flattened coding tree when not provided an actual value.
+	func testFlattenedOptionalDecodingToNil() throws {
+		struct FlattenedOptionalDecodingToNil: DeepDecodable {
+			static let codingTree = CodingTree {
+				Key("top", "second", containing: \._key)
+			}
+
+			@Value var key: String?
+		}
+
+		let json = """
+			{}
+			"""
+		let decoded = try decode(FlattenedOptionalDecodingToNil.self, from: json)
 
 		XCTAssertEqual(nil, decoded.key)
 	}

--- a/Tests/DeepCodableTests/WrappedEncodingTests.swift
+++ b/Tests/DeepCodableTests/WrappedEncodingTests.swift
@@ -185,6 +185,51 @@ final class WrappedEncodingTests: XCTestCase {
 		XCTAssertEqual("tenthValue", dict["top"]?["second"]?["third"]?["fourth"]?["fifth"]?["sixth"]?["seventh"]?["eighth"]?["ninth"]?["tenth"])
 	}
 
+	/// Test that encoding a deep ten-level JSON body using a flattened coding tree encodes the correct value.
+	func testFlattenedExcessivelyDeepEncoding() throws {
+		struct FlattenedExcessivelyDeepEncoding: DeepEncodable {
+			static let codingTree = CodingTree {
+				Key("top", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth", containing: \._key)
+			}
+
+
+			@Value var key: String
+
+			init(key: String) {
+				self.key = key
+			}
+		}
+
+		let encoded = try encode(FlattenedExcessivelyDeepEncoding(key: "tenthValue"))
+
+		// We can't compare JSON strings here since key ordering is non-deterministic, so decode to a `Dictionary` instead.
+		let dict = try decode(
+			[
+				String: [
+					String: [
+						String: [
+							String: [
+								String: [
+									String: [
+										String: [
+											String: [
+												String: [
+													String: String
+												]
+											]
+										]
+									]
+								]
+							]
+						]
+					]
+				]
+			].self,
+			from: encoded
+		)
+		XCTAssertEqual("tenthValue", dict["top"]?["second"]?["third"]?["fourth"]?["fifth"]?["sixth"]?["seventh"]?["eighth"]?["ninth"]?["tenth"])
+	}
+
 	/// Test that encoding a deep ten-level JSON body with two keys in different branches encodes the correct values.
 	func testBranchedExcessivelyDeepEncoding() throws {
 		struct BranchedExcessivelyDeepEncoding: DeepEncodable {
@@ -261,6 +306,58 @@ final class WrappedEncodingTests: XCTestCase {
 		XCTAssertEqual("tenth2Value", dict["top"]?["second"]?["third"]?["fourth"]?["fifth"]?["sixth2"]?["seventh2"]?["eighth2"]?["ninth2"]?["tenth2"])
 	}
 
+	/// Test that encoding a deep ten-level JSON body with two keys in different branches using a flattened coding tree encodes the correct values.
+	func testFlattenedBranchedExcessivelyDeepEncoding() throws {
+		struct FlattenedBranchedExcessivelyDeepEncoding: DeepEncodable {
+			static let codingTree = CodingTree {
+				Key("top", "second", "third", "fourth", "fifth") {
+					Key("sixth1", "seventh1", "eighth1", "ninth1", "tenth1", containing: \._key1)
+					Key("sixth2", "seventh2", "eighth2", "ninth2", "tenth2", containing: \._key2)
+				}
+			}
+
+
+			@Value var key1: String
+			@Value var key2: String
+
+			init(key1: String, key2: String) {
+				self.key1 = key1
+				self.key2 = key2
+			}
+		}
+
+		let encoded = try encode(FlattenedBranchedExcessivelyDeepEncoding(key1: "tenth1Value", key2: "tenth2Value"))
+
+		// We can't compare JSON strings here since key ordering is non-deterministic, so decode to a `Dictionary` instead.
+		let dict = try decode(
+			[
+				String: [
+					String: [
+						String: [
+							String: [
+								String: [
+									String: [
+										String: [
+											String: [
+												String: [
+													String: String
+												]
+											]
+										]
+									]
+								]
+							]
+						]
+					]
+				]
+			].self,
+			from: encoded
+		)
+		XCTAssertEqual("tenth1Value", dict["top"]?["second"]?["third"]?["fourth"]?["fifth"]?["sixth1"]?["seventh1"]?["eighth1"]?["ninth1"]?["tenth1"])
+		XCTAssertEqual("tenth2Value", dict["top"]?["second"]?["third"]?["fourth"]?["fifth"]?["sixth2"]?["seventh2"]?["eighth2"]?["ninth2"]?["tenth2"])
+	}
+
+
 	/// Test that optionals encode correctly when provided an actual value.
 	func testOptionalEncodingToValue() throws {
 		struct OptionalEncodingToValue: DeepEncodable {
@@ -286,6 +383,30 @@ final class WrappedEncodingTests: XCTestCase {
 		XCTAssertEqual("secondValue", dict["top"]?["second"])
 	}
 
+	/// Test that optionals encode correctly using a flattened coding tree when provided an actual value.
+	func testFlattenedOptionalEncodingToValue() throws {
+		struct FlattenedOptionalEncodingToValue: DeepEncodable {
+			static let codingTree = CodingTree {
+				Key("top", "second", containing: \._key)
+			}
+
+
+			@Value var key: String?
+
+			init(key: String? = nil) {
+				self.key = key
+			}
+		}
+
+
+		let encoded = try encode(FlattenedOptionalEncodingToValue(key: "secondValue"))
+
+		// We can't compare JSON strings here since key ordering is non-deterministic, so decode to a `Dictionary` instead.
+		let dict = try decode([String: [String: String]].self, from: encoded)
+		XCTAssertEqual("secondValue", dict["top"]?["second"])
+	}
+
+
 	/// Test that optionals encode correctly when not provided an actual value.
 	func testOptionalEncodingToNil() throws {
 		struct OptionalEncodingToNil: DeepEncodable {
@@ -308,6 +429,28 @@ final class WrappedEncodingTests: XCTestCase {
 		let actual = try encode(OptionalEncodingToNil(key: nil))
 		XCTAssertEqual(expected, actual)
 	}
+
+	/// Test that optionals encode correctly using a flattened coding tree when not provided an actual value.
+	func testFlattenedOptionalEncodingToNil() throws {
+		struct FlattenedOptionalEncodingToNil: DeepEncodable {
+			static let codingTree = CodingTree {
+				Key("top", "second", containing: \._key)
+			}
+
+
+			@Value var key: String?
+
+			init(key: String? = nil) {
+				self.key = key
+			}
+		}
+
+
+		let expected = "{}"
+		let actual = try encode(FlattenedOptionalEncodingToNil(key: nil))
+		XCTAssertEqual(expected, actual)
+	}
+
 
 	/// Test that integers encode correctly.
 	func testIntEncoding() throws {


### PR DESCRIPTION
This eliminates a lot of the boilerplate for specifying intermediate keys.

Thanks [Sam Deane](https://forums.swift.org/t/deepcodable-encode-and-decode-deeply-nested-data-into-flat-swift-objects/59136/4) for the suggestion!